### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_disable_protection.yml
+++ b/.github/workflows/_disable_protection.yml
@@ -1,12 +1,15 @@
 name: disable branch protection rules
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:
       branch:
-        type: string
-        description: 'Branch to checkout'
-        required: true
+       type: string
+       description: 'Branch to checkout'
+       required: true
     secrets:
       TOKEN:
         required: true

--- a/.github/workflows/promote-developpement-prod.yml
+++ b/.github/workflows/promote-developpement-prod.yml
@@ -1,5 +1,8 @@
 name: Promote Developpement to Production
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:
@@ -37,6 +40,8 @@ jobs:
     name: Disable Branch Protection
     uses: ./.github/workflows/_disable_protection.yml
     needs: create-release
+    permissions:
+      contents: write
     with:
       branch: dev
     secrets:
@@ -55,6 +60,8 @@ jobs:
     name: Update Developpement
     runs-on: ubuntu-latest
     needs: [disable-dev-protection, disable-prod-protection, create-release]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
 
@@ -71,6 +78,8 @@ jobs:
     name: Update Production
     runs-on: ubuntu-latest
     needs: update-developpement
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@master
 
@@ -97,6 +106,8 @@ jobs:
     name: Enable Release-Developpement Branch Protection
     uses: ./.github/workflows/_enable_protection.yml
     needs: update-production
+    permissions:
+      contents: write
     with:
       branch: prod
       lock: true

--- a/.github/workflows/release-developpement.yml
+++ b/.github/workflows/release-developpement.yml
@@ -1,5 +1,8 @@
 name: Release Developpement
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 5 * * *' # Every day at 5am UTC (adjust if needed)

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   disable-protection:
     name: Deactivate Branch Protection
+    permissions:
+      contents: read
     uses: ./.github/workflows/_disable_protection.yml
     with:
       branch: release-prod
@@ -15,6 +17,8 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs: disable-protection
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +45,8 @@ jobs:
 
   activate-protection:
     name: Activate Branch Protection
+    permissions:
+      contents: read
     uses: ./.github/workflows/_enable_protection.yml
     needs: merge
     with:


### PR DESCRIPTION
Potential fix for [https://github.com/Melomania-be/front/security/code-scanning/21](https://github.com/Melomania-be/front/security/code-scanning/21)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the least privileges required for all jobs. Additionally, we will add job-specific `permissions` blocks for jobs that require elevated permissions. For example:
- Jobs that involve merging branches (`update-developpement`, `update-production`) will need `contents: write`.
- Jobs that interact with branch protection rules (`disable-dev-protection`, `enable-dev-protection`, etc.) will need `contents: write`.

This approach ensures that each job has only the permissions it needs, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
