### PR TITLE
Add PDF export for contacts and project participants (#63)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1332,7 +1332,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -1345,7 +1344,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"android"
@@ -1358,7 +1356,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1371,7 +1368,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -1384,7 +1380,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1397,7 +1392,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1410,7 +1404,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1423,7 +1416,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1436,7 +1428,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1449,7 +1440,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1462,7 +1452,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1475,7 +1464,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1488,7 +1476,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"linux"
@@ -1501,7 +1488,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1514,7 +1500,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"
@@ -1527,7 +1512,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"optional": true,
 			"os": [
 				"win32"

--- a/src/routes/contacts/[id]/+page.svelte
+++ b/src/routes/contacts/[id]/+page.svelte
@@ -24,7 +24,10 @@
 		messenger: true,
 		comments: true,
 		instruments: true,
-		projects: true
+		projects: true,
+		validated: false,
+		createdAt: false,
+		updatedAt: false
 	};
 
 	onMount(async () => {
@@ -92,55 +95,107 @@
 
 	function exportPdf() {
 		const doc = new jsPDF();
+		const blue: [number, number, number] = [107, 154, 217];
 
-		doc.setFontSize(18);
-		doc.text(`${contact.firstName} ${contact.lastName}`, 14, 20);
+		// Titre en grand et coloré
+		doc.setTextColor(blue[0], blue[1], blue[2]);
+		doc.setFontSize(24);
+		doc.setFont('helvetica', 'bold');
+		doc.text(`${contact.firstName} ${contact.lastName}`, 14, 22);
 
-		const infoRows = [];
-		if (exportFields.email) infoRows.push(['Email', contact.email ?? '']);
-		if (exportFields.phone) infoRows.push(['Téléphone', contact.phone ?? '']);
-		if (exportFields.messenger) infoRows.push(['Messenger', contact.messenger ?? '']);
-		if (exportFields.comments) infoRows.push(['Commentaires', contact.comments ?? '']);
+		// Ligne colorée sous le titre
+		doc.setDrawColor(blue[0], blue[1], blue[2]);
+		doc.setLineWidth(0.8);
+		doc.line(14, 26, 196, 26);
 
-		infoRows.push(['Validé', contact.validated ? 'Oui' : 'Non']);
-		infoRows.push(['Créé le', contact.createdAt ? new Date(contact.createdAt).toLocaleDateString('fr-BE') : '']);
-		infoRows.push(['Modifié le', contact.updatedAt ? new Date(contact.updatedAt).toLocaleDateString('fr-BE') : '']);
+		// Date d'export à droite
+		doc.setTextColor(120, 120, 120);
+		doc.setFontSize(9);
+		doc.setFont('helvetica', 'normal');
+		const today = new Date().toLocaleDateString('en-GB');
+		doc.text(`Exported on ${today}`, 196, 22, { align: 'right' });
 
-		autoTable(doc, {
-			startY: 30,
-			head: [['Champ', 'Valeur']],
-			body: infoRows,
-			styles: { fontSize: 11 },
-			headStyles: { fillColor: [107, 154, 217] }
-		});
+		// Retour aux couleurs/styles par défaut pour la suite
+		doc.setTextColor(0, 0, 0);
 
+		let currentY = 36;
+
+		// Section "Contact information"
+		const infoRows: any[] = [];
+		if (exportFields.email) infoRows.push([{ content: 'Email', styles: { fontStyle: 'bold' } }, contact.email ?? '']);
+		if (exportFields.phone) infoRows.push([{ content: 'Phone', styles: { fontStyle: 'bold' } }, contact.phone ?? '']);
+		if (exportFields.messenger) infoRows.push([{ content: 'Messenger', styles: { fontStyle: 'bold' } }, contact.messenger ?? '']);
+		if (exportFields.comments) infoRows.push([{ content: 'Comments', styles: { fontStyle: 'bold' } }, contact.comments ?? '']);
+		if (exportFields.validated) infoRows.push([{ content: 'Validated', styles: { fontStyle: 'bold' } }, contact.validated ? 'Yes' : 'No']);
+		if (exportFields.createdAt) infoRows.push([{ content: 'Created on', styles: { fontStyle: 'bold' } }, contact.createdAt ? new Date(contact.createdAt).toLocaleDateString('en-GB') : '']);
+		if (exportFields.updatedAt) infoRows.push([{ content: 'Updated on', styles: { fontStyle: 'bold' } }, contact.updatedAt ? new Date(contact.updatedAt).toLocaleDateString('en-GB') : '']);
+
+		if (infoRows.length > 0) {
+			doc.setFontSize(13);
+			doc.setFont('helvetica', 'bold');
+			doc.setTextColor(blue[0], blue[1], blue[2]);
+			doc.text('Contact information', 14, currentY);
+			currentY += 4;
+
+			autoTable(doc, {
+				startY: currentY,
+				head: [['Field', 'Value']],
+				body: infoRows,
+				styles: { fontSize: 11, cellPadding: 4 },
+				headStyles: { fillColor: blue, textColor: 255, fontStyle: 'bold' },
+				alternateRowStyles: { fillColor: [245, 248, 252] },
+				columnStyles: { 0: { cellWidth: 45 } }
+			});
+			currentY = (doc as any).lastAutoTable.finalY + 10;
+		}
+
+		// Section "Instruments"
 		if (exportFields.instruments) {
 			const instrumentRows = (contact.instruments ?? []).map((i) => [
-				i.name ?? '',
+				{ content: i.name ?? '', styles: { fontStyle: 'bold' as const } },
 				i.pivot_proficiency_level ?? ''
 			]);
 
 			if (instrumentRows.length > 0) {
+				doc.setFontSize(13);
+				doc.setFont('helvetica', 'bold');
+				doc.setTextColor(blue[0], blue[1], blue[2]);
+				doc.text('Instruments', 14, currentY);
+				currentY += 4;
+
 				autoTable(doc, {
-					head: [['Instrument', 'Niveau']],
+					startY: currentY,
+					head: [['Instrument', 'Level']],
 					body: instrumentRows,
-					styles: { fontSize: 11 },
-					headStyles: { fillColor: [107, 154, 217] }
+					styles: { fontSize: 11, cellPadding: 4 },
+					headStyles: { fillColor: blue, textColor: 255, fontStyle: 'bold' },
+					alternateRowStyles: { fillColor: [245, 248, 252] },
+					columnStyles: { 0: { cellWidth: 60 } }
 				});
+				currentY = (doc as any).lastAutoTable.finalY + 10;
 			}
 		}
 
+		// Section "Projects"
 		if (exportFields.projects) {
 			const projectRows = (contact.participants ?? []).map((p) => [
 				p.project?.name ?? ''
 			]);
 
 			if (projectRows.length > 0) {
+				doc.setFontSize(13);
+				doc.setFont('helvetica', 'bold');
+				doc.setTextColor(blue[0], blue[1], blue[2]);
+				doc.text('Projects', 14, currentY);
+				currentY += 4;
+
 				autoTable(doc, {
-					head: [['Projets joués']],
+					startY: currentY,
+					head: [['Project']],
 					body: projectRows,
-					styles: { fontSize: 11 },
-					headStyles: { fillColor: [107, 154, 217] }
+					styles: { fontSize: 11, cellPadding: 4 },
+					headStyles: { fillColor: blue, textColor: 255, fontStyle: 'bold' },
+					alternateRowStyles: { fillColor: [245, 248, 252] }
 				});
 			}
 		}
@@ -152,25 +207,34 @@
 <div class="bg-[#E7E7E7] p-4 h-screen">
 	<ContactModifier mode="modify" {contact} {instruments} />
 	<div class="w-full mt-4 p-4 bg-white border-2 border-gray-500 rounded-xl shadow">
-		<p class="font-semibold text-gray-600 mb-2">Champs à exporter :</p>
+		<p class="font-semibold text-gray-600 mb-2">Fields to export:</p>
 		<div class="flex flex-wrap gap-4 mb-4">
 			<label class="flex items-center gap-2">
 				<input type="checkbox" bind:checked={exportFields.email} /> Email
 			</label>
 			<label class="flex items-center gap-2">
-				<input type="checkbox" bind:checked={exportFields.phone} /> Téléphone
+				<input type="checkbox" bind:checked={exportFields.phone} /> Phone
 			</label>
 			<label class="flex items-center gap-2">
 				<input type="checkbox" bind:checked={exportFields.messenger} /> Messenger
 			</label>
 			<label class="flex items-center gap-2">
-				<input type="checkbox" bind:checked={exportFields.comments} /> Commentaires
+				<input type="checkbox" bind:checked={exportFields.comments} /> Comments
 			</label>
 			<label class="flex items-center gap-2">
 				<input type="checkbox" bind:checked={exportFields.instruments} /> Instruments
 			</label>
 			<label class="flex items-center gap-2">
-				<input type="checkbox" bind:checked={exportFields.projects} /> Projets
+				<input type="checkbox" bind:checked={exportFields.projects} /> Projects
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.validated} /> Validated
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.createdAt} /> Created on
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.updatedAt} /> Updated on
 			</label>
 		</div>
 		<div class="flex justify-end">

--- a/src/routes/contacts/[id]/+page.svelte
+++ b/src/routes/contacts/[id]/+page.svelte
@@ -7,6 +7,7 @@
 	import AccountingTable from '$lib/components/AccountingTable.svelte';
 	import type { ExpenseCategory } from '$lib/types/ExpenseCategory.js';
 	import { onMount } from 'svelte';
+	import { jsPDF } from 'jspdf';
 	import autoTable from 'jspdf-autotable';
 
 	export let data;
@@ -16,6 +17,15 @@
 
 	let contactAccountings: Accounting[] = [];
 	let categories: ExpenseCategory[];
+
+	let exportFields = {
+		email: true,
+		phone: true,
+		messenger: true,
+		comments: true,
+		instruments: true,
+		projects: true
+	};
 
 	onMount(async () => {
 		await fetchAccountingContact();
@@ -79,10 +89,99 @@
 		}
 		console.log(projectConcerts)
 	});
+
+	function exportPdf() {
+		const doc = new jsPDF();
+
+		doc.setFontSize(18);
+		doc.text(`${contact.firstName} ${contact.lastName}`, 14, 20);
+
+		const infoRows = [];
+		if (exportFields.email) infoRows.push(['Email', contact.email ?? '']);
+		if (exportFields.phone) infoRows.push(['Téléphone', contact.phone ?? '']);
+		if (exportFields.messenger) infoRows.push(['Messenger', contact.messenger ?? '']);
+		if (exportFields.comments) infoRows.push(['Commentaires', contact.comments ?? '']);
+
+		infoRows.push(['Validé', contact.validated ? 'Oui' : 'Non']);
+		infoRows.push(['Créé le', contact.createdAt ? new Date(contact.createdAt).toLocaleDateString('fr-BE') : '']);
+		infoRows.push(['Modifié le', contact.updatedAt ? new Date(contact.updatedAt).toLocaleDateString('fr-BE') : '']);
+
+		autoTable(doc, {
+			startY: 30,
+			head: [['Champ', 'Valeur']],
+			body: infoRows,
+			styles: { fontSize: 11 },
+			headStyles: { fillColor: [107, 154, 217] }
+		});
+
+		if (exportFields.instruments) {
+			const instrumentRows = (contact.instruments ?? []).map((i) => [
+				i.name ?? '',
+				i.pivot_proficiency_level ?? ''
+			]);
+
+			if (instrumentRows.length > 0) {
+				autoTable(doc, {
+					head: [['Instrument', 'Niveau']],
+					body: instrumentRows,
+					styles: { fontSize: 11 },
+					headStyles: { fillColor: [107, 154, 217] }
+				});
+			}
+		}
+
+		if (exportFields.projects) {
+			const projectRows = (contact.participants ?? []).map((p) => [
+				p.project?.name ?? ''
+			]);
+
+			if (projectRows.length > 0) {
+				autoTable(doc, {
+					head: [['Projets joués']],
+					body: projectRows,
+					styles: { fontSize: 11 },
+					headStyles: { fillColor: [107, 154, 217] }
+				});
+			}
+		}
+
+		doc.save(`contact-${contact.id}.pdf`);
+	}
 </script>
 
 <div class="bg-[#E7E7E7] p-4 h-screen">
 	<ContactModifier mode="modify" {contact} {instruments} />
+	<div class="w-full mt-4 p-4 bg-white border-2 border-gray-500 rounded-xl shadow">
+		<p class="font-semibold text-gray-600 mb-2">Champs à exporter :</p>
+		<div class="flex flex-wrap gap-4 mb-4">
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.email} /> Email
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.phone} /> Téléphone
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.messenger} /> Messenger
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.comments} /> Commentaires
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.instruments} /> Instruments
+			</label>
+			<label class="flex items-center gap-2">
+				<input type="checkbox" bind:checked={exportFields.projects} /> Projets
+			</label>
+		</div>
+		<div class="flex justify-end">
+			<button
+				on:click={exportPdf}
+				class="px-4 py-2 bg-[#6B9AD9] text-white font-semibold rounded-lg shadow hover:bg-[#5a89c8] transition-all"
+			>
+				Export PDF
+			</button>
+		</div>
+	</div>
 	<div
 		class="w-full p-4 mt-4 bg-white border-2 border-gray-500 rounded-xl shadow dark:bg-gray-800 dark:border-gray-700"
 	>

--- a/src/routes/projects/[id]/management/participants/+page.svelte
+++ b/src/routes/projects/[id]/management/participants/+page.svelte
@@ -323,32 +323,59 @@
 
 	function exportParticipantsPdf() {
 		const doc = new jsPDF();
+		const blue: [number, number, number] = [107, 154, 217];
 
-		doc.setFontSize(18);
-		doc.text('Participants du projet', 14, 20);
+		// Titre stylisé
+		doc.setTextColor(blue[0], blue[1], blue[2]);
+		doc.setFontSize(24);
+		doc.setFont('helvetica', 'bold');
+		doc.text('Project participants', 14, 22);
 
+		// Ligne colorée sous le titre
+		doc.setDrawColor(blue[0], blue[1], blue[2]);
+		doc.setLineWidth(0.8);
+		doc.line(14, 26, 196, 26);
+
+		// Date d'export à droite
+		doc.setTextColor(120, 120, 120);
+		doc.setFontSize(9);
+		doc.setFont('helvetica', 'normal');
+		const today = new Date().toLocaleDateString('en-GB');
+		doc.text(`Exported on ${today}`, 196, 22, { align: 'right' });
+
+		// Nom du projet en sous-titre
+		doc.setTextColor(60, 60, 60);
+		doc.setFontSize(12);
+		doc.setFont('helvetica', 'normal');
 		if (project?.name) {
-			doc.setFontSize(12);
-			doc.text(project.name, 14, 28);
+			doc.text(project.name, 14, 34);
 		}
 
-		const rows = participants.map((p) => [
-			p.contact?.firstName ?? '',
-			p.contact?.lastName ?? '',
-			p.contact?.email ?? '',
-			p.contact?.phone ?? '',
-			p.section?.name ?? ''
-		]);
+		doc.setTextColor(0, 0, 0);
 
-		autoTable(doc, {
-			startY: 36,
-			head: [['Prénom', 'Nom', 'Email', 'Téléphone', 'Section']],
-			body: rows,
-			styles: { fontSize: 10 },
-			headStyles: { fillColor: [107, 154, 217] }
+		// Tableau des participants
+		const rows = participants.map((p) => {
+			const sectionName = p.section?.name ?? '';
+			const sectionText = p.isSectionLeader ? `${sectionName} (section leader)` : sectionName;
+			return [
+				p.contact?.firstName ?? '',
+				p.contact?.lastName ?? '',
+				p.contact?.email ?? '',
+				p.contact?.phone ?? '',
+				sectionText
+			];
 		});
 
-		doc.save(`participants-projet-${data.id}.pdf`);
+		autoTable(doc, {
+			startY: 42,
+			head: [['First name', 'Last name', 'Email', 'Phone', 'Section']],
+			body: rows,
+			styles: { fontSize: 10, cellPadding: 3 },
+			headStyles: { fillColor: blue, textColor: 255, fontStyle: 'bold' },
+			alternateRowStyles: { fillColor: [245, 248, 252] }
+		});
+
+		doc.save(`participants-project-${data.id}.pdf`);
 	}
 </script>
 
@@ -362,8 +389,9 @@
 					<p class={isMobile ? '' : ''}>
 						You have <strong class="text-red-400 mx-1">{participantNotValidated}</strong>
 						{participantNotValidated === 1 ? 'participant' : 'participants'} waiting for validation
-					</p>
-					<a
+						</p>
+						<a
+					
 						href="/projects/{data.id}/management/validation"
 						class="ml-auto inline-flex items-center px-3 py-2 text-sm font-semibold text-center text-white bg-[#6B9AD9] rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 					>

--- a/src/routes/projects/[id]/management/participants/+page.svelte
+++ b/src/routes/projects/[id]/management/participants/+page.svelte
@@ -15,7 +15,8 @@
 	import RegistrationForm from '$lib/components/registration/RegistrationForm.svelte';
 	import type { Registration } from '$lib/types/Registration';
 	import type { Form } from '$lib/types/Form';
-
+	import { jsPDF } from 'jspdf';
+	import autoTable from 'jspdf-autotable';
 	export let data;
 
 	let project: Project | undefined;
@@ -148,24 +149,20 @@
 		for (const acc of accountings) {
 			if(acc.isMusicianFee){
 				if (acc.contactId != null) {
-					// Initialise à 0 si c'est la première fois qu'on voit ce contact
 					if (!paymentsByContactMusicianFee[acc.contactId]) {
 						paymentsByContactMusicianFee[acc.contactId] = 0;
 					}
 
-					// Ajoute le montant (en s'assurant qu'il est bien un nombre)
 					paymentsByContactMusicianFee[acc.contactId] += Number(acc.amount);
 				}
 				
 			}
 			else{
 				if (acc.contactId != null) {
-					// Initialise à 0 si c'est la première fois qu'on voit ce contact
 					if (!paymentsByContactAdditionnal[acc.contactId]) {
 						paymentsByContactAdditionnal[acc.contactId] = 0;
 					}
 
-					// Ajoute le montant (en s'assurant qu'il est bien un nombre)
 					paymentsByContactAdditionnal[acc.contactId] += Number(acc.amount);
 				}
 				console.log(acc.amount)
@@ -280,13 +277,13 @@
 	function parseQuestionAndAnswers(raw: string): string {
 		const [question, answersPart] = raw.split(':', 2);
 
-		if (!answersPart) return raw; // cas où il n’y a pas de ":"
+		if (!answersPart) return raw;
 
 		const answers = answersPart
-			.replace(/^;+|;+$/g, '') // retire les ; au début/fin
-			.split(';') // transforme en tableau
-			.map((s) => s.trim()) // nettoie les espaces
-			.filter((s) => s.length > 0); // ignore les vides
+			.replace(/^;+|;+$/g, '')
+			.split(';')
+			.map((s) => s.trim())
+			.filter((s) => s.length > 0);
 
 		return `${question.trim()} (${answers.join(', ')})`;
 	}
@@ -323,6 +320,36 @@
 		console.log(p.id, p.contact?.email);
 	});
 	}
+
+	function exportParticipantsPdf() {
+		const doc = new jsPDF();
+
+		doc.setFontSize(18);
+		doc.text('Participants du projet', 14, 20);
+
+		if (project?.name) {
+			doc.setFontSize(12);
+			doc.text(project.name, 14, 28);
+		}
+
+		const rows = participants.map((p) => [
+			p.contact?.firstName ?? '',
+			p.contact?.lastName ?? '',
+			p.contact?.email ?? '',
+			p.contact?.phone ?? '',
+			p.section?.name ?? ''
+		]);
+
+		autoTable(doc, {
+			startY: 36,
+			head: [['Prénom', 'Nom', 'Email', 'Téléphone', 'Section']],
+			body: rows,
+			styles: { fontSize: 10 },
+			headStyles: { fillColor: [107, 154, 217] }
+		});
+
+		doc.save(`participants-projet-${data.id}.pdf`);
+	}
 </script>
 
 <ProjectHeadDisplayer {project} selectedTab={1} />
@@ -351,8 +378,14 @@
 			<div class="flex items-center">
 				<h1 class="font-bold text-lg">PARTICIPANTS</h1>
 				<button
-					on:click={() => goto(`${urlFront}/creation`)}
+					on:click={exportParticipantsPdf}
 					class="ml-auto px-4 py-2 text-sm bg-[#6B9AD9] text-white rounded-lg font-semibold hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75"
+				>
+					Export PDF
+				</button>
+				<button
+					on:click={() => goto(`${urlFront}/creation`)}
+					class="ml-2 px-4 py-2 text-sm bg-[#6B9AD9] text-white rounded-lg font-semibold hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75"
 				>
 					Add a participant
 				</button>
@@ -398,20 +431,6 @@
 							{/each}
 						</div>
 					</div>
-					<!--
-					<div class="flex w-full justify-center">
-						<select
-							on:change={changeSorting}
-							class="w-1/2 items-center flex rounded-lg border-2 border-gray-500"
-							bind:value={sorting}
-						>
-							<option value={''}>None</option>
-							<option value={'email'}>Email</option>
-							<option value={'firstName'}>First Name</option>
-							<option value={'lastName'}>Last Name</option>
-						</select>
-					</div>
-					-->
 				</div>
 				<div class="w-full overflow-x-auto">
 					<table


### PR DESCRIPTION
Adds two PDF exports for #63:

- Button on a single contact page, with checkboxes to pick which fields to include
- Button on the project participants page

Uses jspdf + jspdf-autotable (already in the project).

Not done yet: export from contact lists and bulk export from search. Waiting for #164 to be fixed first.

Side note: while testing, I noticed instruments added when creating a new contact don't get saved (they only persist when added later via "modify" on an existing contact). Might be worth opening a separate issue.