### PR TITLE
fix: add confirmation dialog before deleting a content block

### DIFF
--- a/src/lib/components/callsheet/CallsheetModifier.svelte
+++ b/src/lib/components/callsheet/CallsheetModifier.svelte
@@ -194,11 +194,14 @@
 
 	// Fonction pour supprimer un contenu spécifique
 	function removeContent(contentToRemove: any) {
-		if (!callsheet || !callsheet.contents) return;
+    if (!callsheet || !callsheet.contents) return;
 
-		callsheet.contents = callsheet.contents.filter(content => content !== contentToRemove);
-		callsheet = callsheet; // Force la réactivité
-	}
+    const confirmDelete = confirm('Êtes-vous sûr de vouloir supprimer ce bloc ?');
+    if (!confirmDelete) return;
+
+    callsheet.contents = callsheet.contents.filter(content => content !== contentToRemove);
+    callsheet = callsheet; // Force la réactivité
+}
 
 	// Fonction pour ajouter un nouveau contenu
 	function addNewContent() {


### PR DESCRIPTION
Bug found during testing of issue #99.

When clicking the delete button on a content block in the callsheet 
editor, the block was deleted immediately without any confirmation. 
This could lead to accidental data loss.

Added a confirmation dialog before removing the block in the 
removeContent function in CallsheetModifier.svelte.