### PR TITLE
fix: add version field length validation to prevent database error

### DIFF
--- a/src/lib/components/callsheet/CallsheetModifier.svelte
+++ b/src/lib/components/callsheet/CallsheetModifier.svelte
@@ -33,8 +33,10 @@
 		}
 
 		if (!callsheet.version || callsheet.version.trim() === '') {
-			errors.push('La version est requise');
-		}
+    errors.push('La version est requise');
+} else if (callsheet.version.length > 255) {
+    errors.push('La version ne peut pas dépasser 255 caractères');
+}
 
 		if (!callsheet.contents || callsheet.contents.length === 0) {
 			errors.push('Au moins un contenu est requis');


### PR DESCRIPTION
Bug found during testing of issue #99.

Entering a version string longer than 255 characters caused a raw 
database error to be displayed to the user: "valeur trop longue 
pour le type character varying(255)". The error was not handled 
gracefully on the frontend.

Added a length validation check in the validateCallsheet function 
in CallsheetModifier.svelte. If the version exceeds 255 characters, 
a friendly error message is shown and the form is not submitted.