### PR TITLE
fix: prevent infinite reactive loop when adding content blocks

### DIFF
--- a/src/lib/components/callsheet/CallsheetModifier.svelte
+++ b/src/lib/components/callsheet/CallsheetModifier.svelte
@@ -21,7 +21,7 @@
 	}
 
 	// Compteur pour générer des IDs uniques pour les nouveaux contenus
-	$: contentIdCounter = Math.max(...(callsheet?.contents?.map(c => c.id || 0) || [0])) + 1;
+	let contentIdCounter = Math.max(...(callsheet?.contents?.map(c => c.id || 0) || [0])) + 1;
 
 	// Validation des champs requis
 	function validateCallsheet() {


### PR DESCRIPTION
Bug found during testing of issue #99.

When creating a new callsheet, clicking "Add content" more than once 
caused the page to become unresponsive. The issue was caused by a 
reactive statement ($:) for contentIdCounter that triggered an 
infinite loop every time callsheet.contents changed.

Changed contentIdCounter from a reactive statement ($:) to a regular 
variable (let) in CallsheetModifier.svelte.