### PR TITLE
fix: create a proper copy when using new callsheet from last one

### DIFF
--- a/src/routes/projects/[id]/management/callsheets/[callsheetId]/creation/+page.svelte
+++ b/src/routes/projects/[id]/management/callsheets/[callsheetId]/creation/+page.svelte
@@ -19,7 +19,7 @@
 
 		if (callsheetResponse.ok) {
 			callsheet = await callsheetResponse.json();
-			callsheet.id = null;
+			callsheet = { ...callsheet, id: null };
 		} else {
 			console.error('Failed to fetch callsheet');
 		}


### PR DESCRIPTION
Bug found during testing of issue #99.

When clicking "New callsheet from the last one", the two callsheets 
were linked. Editing one also modified the other. This was caused 
by mutating the original callsheet object directly with 
callsheet.id = null instead of creating a proper copy.

Changed to callsheet = { ...callsheet, id: null } in 
[callsheetId]/creation/+page.svelte to create a new independent 
copy of the callsheet object.